### PR TITLE
Redirect errors to stderr

### DIFF
--- a/cmd/distro.go
+++ b/cmd/distro.go
@@ -58,7 +58,7 @@ var distroAddCmd = &cobra.Command{
 		if checkError(err) == nil {
 			fmt.Printf("Distro %s created", newDistro.Name)
 		} else {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 	},
@@ -85,7 +85,7 @@ var distroEditCmd = &cobra.Command{
 		var updateDistro, err = Client.GetDistro(dname)
 
 		if checkError(err) != nil {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 
@@ -159,7 +159,7 @@ var distroEditCmd = &cobra.Command{
 		err = Client.UpdateDistro(updateDistro)
 
 		if checkError(err) != nil {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 	},
@@ -179,7 +179,7 @@ var distroFindCmd = &cobra.Command{
 			   	str, _ := json.MarshalIndent(distro, "", " ")
 			   	fmt.Println(string(str))
 			} else {
-			   	fmt.Println(err.Error())
+			   	fmt.Fprintln(os.Stderr, err.Error())
 			}
 		*/
 		notImplemented()
@@ -197,7 +197,7 @@ var distroListCmd = &cobra.Command{
 		if checkError(err) == nil {
 			fmt.Println(distros)
 		} else {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 	},
@@ -212,7 +212,7 @@ var distroRemoveCmd = &cobra.Command{
 		dname, _ := cmd.Flags().GetString("name")
 		err := Client.DeleteDistro(dname)
 		if checkError(err) != nil {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 	},

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -71,7 +71,7 @@ var profileAddCmd = &cobra.Command{
 		if checkError(err) == nil {
 			fmt.Printf("Profile %s created", newProfile.Name)
 		} else {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 		}
 	},
 }
@@ -107,7 +107,7 @@ var profileEditCmd = &cobra.Command{
 		var updateProfile, err = Client.GetProfile(pname)
 
 		if checkError(err) != nil {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 
@@ -242,7 +242,7 @@ var profileEditCmd = &cobra.Command{
 		err = Client.UpdateProfile(updateProfile)
 
 		if checkError(err) != nil {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 
@@ -280,7 +280,7 @@ var profileListCmd = &cobra.Command{
 		if checkError(err) == nil {
 			fmt.Println(profiles)
 		} else {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 	},
@@ -295,7 +295,7 @@ var profileRemoveCmd = &cobra.Command{
 		pname, _ := cmd.Flags().GetString("name")
 		err := Client.DeleteProfile(pname)
 		if checkError(err) != nil {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 	},

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -57,7 +57,7 @@ var repoAddCmd = &cobra.Command{
 		if checkError(err) == nil {
 			fmt.Printf("Repo %s created", newRepo.Name)
 		} else {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 	},
@@ -94,7 +94,7 @@ var repoEditCmd = &cobra.Command{
 		var updateRepo, err = Client.GetRepo(rname)
 
 		if checkError(err) != nil {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 
@@ -163,7 +163,7 @@ var repoEditCmd = &cobra.Command{
 		err = Client.UpdateRepo(updateRepo)
 
 		if checkError(err) != nil {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 	},
@@ -190,7 +190,7 @@ var repoListCmd = &cobra.Command{
 		if checkError(err) == nil {
 			fmt.Println(repos)
 		} else {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 		}
 	},
 }
@@ -204,7 +204,7 @@ var repoRemoveCmd = &cobra.Command{
 		rname, _ := cmd.Flags().GetString("name")
 		err := Client.DeleteRepo(rname)
 		if checkError(err) != nil {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 		}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,7 +65,7 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		// TODO: Do we need the output what configl file is used?
+		// TODO: Do we need the output what config file is used?
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
 	generateCobblerClient()
@@ -73,7 +73,7 @@ func initConfig() {
 
 func checkError(err error) error {
 	if err != nil {
-		return fmt.Errorf("error occured: %s", err)
+		return err
 	} else {
 		return nil
 	}
@@ -91,12 +91,12 @@ func generateCobblerClient() {
 	login, err := Client.Login()
 
 	if !login || err != nil {
-		fmt.Println(fmt.Errorf("failed to login: %s", err))
+		fmt.Fprintln(os.Stderr, fmt.Errorf("error! Failed to login: %s", err))
 	}
 }
 
 // simply prints a message about functions not implemented in the cobblerclient library
 func notImplemented() {
-	fmt.Println(fmt.Errorf(`error! Not yet implemented in the cobblerclient library
+	fmt.Fprintln(os.Stderr, fmt.Errorf(`error! Not yet implemented in the cobblerclient library
 See https://github.com/cobbler/cobblerclient/issues/4`))
 }

--- a/cmd/system.go
+++ b/cmd/system.go
@@ -102,7 +102,7 @@ var systemAddCmd = &cobra.Command{
 		// See https://github.com/cobbler/cli/issues/38
 		err = newSystem.CreateInterface("default", iface)
 		if checkError(err) != nil {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 
@@ -110,7 +110,7 @@ var systemAddCmd = &cobra.Command{
 		if checkError(err) == nil {
 			fmt.Printf("System %s created", newSystem.Name)
 		} else {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 	},
@@ -147,7 +147,7 @@ var systemEditCmd = &cobra.Command{
 		var updateSystem, err = Client.GetSystem(pname)
 
 		if checkError(err) != nil {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 
@@ -316,7 +316,7 @@ var systemEditCmd = &cobra.Command{
 		err = Client.UpdateSystem(updateSystem)
 
 		if checkError(err) != nil {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 	},
@@ -353,7 +353,7 @@ var systemListCmd = &cobra.Command{
 		if checkError(err) == nil {
 			fmt.Println(systems)
 		} else {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 	},
@@ -408,7 +408,7 @@ var systemRemoveCmd = &cobra.Command{
 		sname, _ := cmd.Flags().GetString("name")
 		err := Client.DeleteSystem(sname)
 		if checkError(err) != nil {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 	},


### PR DESCRIPTION
This will redirect error messaged to `stderr` instead of `stdout`.
