### PR TITLE
Move client generation to CLI methods

### DIFF
--- a/cmd/aclsetup.go
+++ b/cmd/aclsetup.go
@@ -15,6 +15,7 @@ var aclsetupCmd = &cobra.Command{
 	Long:  "Configures users/groups to run the Cobbler CLI as non-root.",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 		// TODO: call cobblerclient
 	},
 }

--- a/cmd/buildiso.go
+++ b/cmd/buildiso.go
@@ -14,6 +14,7 @@ var buildisoCmd = &cobra.Command{
 	Short: "Build an ISO",
 	Long:  "Build all profiles into a bootable CD image. All flags are optional.",
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 		// TODO: call cobblerclient
 	},
 }

--- a/cmd/distro.go
+++ b/cmd/distro.go
@@ -33,6 +33,7 @@ var distroAddCmd = &cobra.Command{
 	Short: "add distribution",
 	Long:  `Adds a distribution.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		var newDistro cobbler.Distro
 		// internal fields (ctime, mtime, depth, uid, source-repos, tree-build-time) cannot be modified
@@ -69,6 +70,7 @@ var distroCopyCmd = &cobra.Command{
 	Short: "copy distribution",
 	Long:  `Copies a distribution.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -79,6 +81,7 @@ var distroEditCmd = &cobra.Command{
 	Short: "edit distribution",
 	Long:  `Edits a distribution.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		// find distro through its name
 		dname, _ := cmd.Flags().GetString("name")
@@ -172,7 +175,7 @@ var distroFindCmd = &cobra.Command{
 	Short: "find distribution",
 	Long:  `Finds a given distribution.`,
 	Run: func(cmd *cobra.Command, args []string) {
-
+		generateCobblerClient()
 		/*
 			dname, _ := cmd.Flags().GetString("name")
 			distro, err = Client.GetDistro(dname)
@@ -193,6 +196,7 @@ var distroListCmd = &cobra.Command{
 	Short: "list all distributions",
 	Long:  `Lists all available distributions.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		distros, err = Client.GetDistros()
 
@@ -210,6 +214,7 @@ var distroRemoveCmd = &cobra.Command{
 	Short: "remove distribution",
 	Long:  `Removes a given distribution.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		dname, _ := cmd.Flags().GetString("name")
 		err := Client.DeleteDistro(dname)
@@ -225,6 +230,7 @@ var distroRenameCmd = &cobra.Command{
 	Short: "rename distribution",
 	Long:  `Renames a given distribution.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -235,6 +241,7 @@ var distroReportCmd = &cobra.Command{
 	Short: "list all distributions in detail",
 	Long:  `Shows detailed information about all distributions.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 		// TODO: call cobblerclient
 		notImplemented()
 	},

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -24,6 +24,8 @@ var fileAddCmd = &cobra.Command{
 	Short: "add file",
 	Long:  `Adds a file.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -34,6 +36,8 @@ var fileCopyCmd = &cobra.Command{
 	Short: "copy file",
 	Long:  `Copies a file.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -44,6 +48,8 @@ var fileEditCmd = &cobra.Command{
 	Short: "edit file",
 	Long:  `Edits a file.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -54,6 +60,8 @@ var fileFindCmd = &cobra.Command{
 	Short: "find file",
 	Long:  `Finds a given file.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -64,6 +72,8 @@ var fileListCmd = &cobra.Command{
 	Short: "list all files",
 	Long:  `Lists all available files.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -74,6 +84,8 @@ var fileRemoveCmd = &cobra.Command{
 	Short: "remove file",
 	Long:  `Removes a given file.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -84,6 +96,8 @@ var fileRenameCmd = &cobra.Command{
 	Short: "rename file",
 	Long:  `Renames a given file.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -94,6 +108,8 @@ var fileReportCmd = &cobra.Command{
 	Short: "list all files in detail",
 	Long:  `Shows detailed information about all files.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},

--- a/cmd/hardlink.go
+++ b/cmd/hardlink.go
@@ -14,6 +14,7 @@ var hardlinkCmd = &cobra.Command{
 	Short: "Hardlink files",
 	Long:  "Hardlink all files where it is possible to improve performance.",
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 		// TODO: call cobblerclient
 	},
 }

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -24,6 +24,8 @@ var imageAddCmd = &cobra.Command{
 	Short: "add image",
 	Long:  `Adds a image.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -34,6 +36,8 @@ var imageCopyCmd = &cobra.Command{
 	Short: "copy image",
 	Long:  `Copies a image.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -44,6 +48,8 @@ var imageEditCmd = &cobra.Command{
 	Short: "edit image",
 	Long:  `Edits a image.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -54,6 +60,8 @@ var imageFindCmd = &cobra.Command{
 	Short: "find image",
 	Long:  `Finds a given image.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -64,6 +72,8 @@ var imageListCmd = &cobra.Command{
 	Short: "list all images",
 	Long:  `Lists all available images.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -74,6 +84,8 @@ var imageRemoveCmd = &cobra.Command{
 	Short: "remove image",
 	Long:  `Removes a given image.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -84,6 +96,8 @@ var imageRenameCmd = &cobra.Command{
 	Short: "rename image",
 	Long:  `Renames a given image.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -94,6 +108,8 @@ var imageimagertCmd = &cobra.Command{
 	Short: "list all images in detail",
 	Long:  `Shows detailed information about all images.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -16,6 +16,7 @@ var importCmd = &cobra.Command{
 See https://cobbler.readthedocs.io/en/latest/quickstart-guide.html#importing-your-first-distribution for more information.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 		// TODO: call cobblerclient
 	},
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -17,6 +17,7 @@ most of the other Cobbler commands (currently: distro, profile, system, repo, im
 Identical to 'cobbler report'`,
 
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 		// TODO: call cobblerclient
 	},
 }

--- a/cmd/menu.go
+++ b/cmd/menu.go
@@ -24,6 +24,8 @@ var menuAddCmd = &cobra.Command{
 	Short: "add menu",
 	Long:  `Adds a menu.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -34,6 +36,8 @@ var menuCopyCmd = &cobra.Command{
 	Short: "copy menu",
 	Long:  `Copies a menu.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -44,6 +48,8 @@ var menuEditCmd = &cobra.Command{
 	Short: "edit menu",
 	Long:  `Edits a menu.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -54,6 +60,8 @@ var menuFindCmd = &cobra.Command{
 	Short: "find menu",
 	Long:  `Finds a given menu.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -64,6 +72,8 @@ var menuListCmd = &cobra.Command{
 	Short: "list all menus",
 	Long:  `Lists all available menus.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -74,6 +84,8 @@ var menuRemoveCmd = &cobra.Command{
 	Short: "remove menu",
 	Long:  `Removes a given menu.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -84,6 +96,8 @@ var menuRenameCmd = &cobra.Command{
 	Short: "rename menu",
 	Long:  `Renames a given menu.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -94,6 +108,8 @@ var menuReportCmd = &cobra.Command{
 	Short: "list all menus in detail",
 	Long:  `Shows detailed information about all menus.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},

--- a/cmd/mgmtclass.go
+++ b/cmd/mgmtclass.go
@@ -24,6 +24,8 @@ var mgmtclassAddCmd = &cobra.Command{
 	Short: "add mgmtclass",
 	Long:  `Adds a mgmtclass.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -34,6 +36,8 @@ var mgmtclassCopyCmd = &cobra.Command{
 	Short: "copy mgmtclass",
 	Long:  `Copies a mgmtclass.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -44,6 +48,8 @@ var mgmtclassEditCmd = &cobra.Command{
 	Short: "edit mgmtclass",
 	Long:  `Edits a mgmtclass.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -54,6 +60,8 @@ var mgmtclassFindCmd = &cobra.Command{
 	Short: "find mgmtclass",
 	Long:  `Finds a given mgmtclass.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -64,6 +72,8 @@ var mgmtclassListCmd = &cobra.Command{
 	Short: "list all mgmtclasses",
 	Long:  `Lists all available mgmtclasses.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -74,6 +84,8 @@ var mgmtclassRemoveCmd = &cobra.Command{
 	Short: "remove mgmtclass",
 	Long:  `Removes a given mgmtclass.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -84,6 +96,8 @@ var mgmtclassRenameCmd = &cobra.Command{
 	Short: "rename mgmtclass",
 	Long:  `Renames a given mgmtclass.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -94,6 +108,8 @@ var mgmtclassReportCmd = &cobra.Command{
 	Short: "list all mgmtclasses in detail",
 	Long:  `Shows detailed information about all mgmtclasses.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},

--- a/cmd/mkloaders.go
+++ b/cmd/mkloaders.go
@@ -17,6 +17,7 @@ then this also generates bootloaders for different architectures then the one of
 The options are configured in the Cobbler settings file.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 		// TODO: call cobblerclient
 	},
 }

--- a/cmd/package.go
+++ b/cmd/package.go
@@ -24,6 +24,8 @@ var packageAddCmd = &cobra.Command{
 	Short: "add package",
 	Long:  `Adds a package.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -34,6 +36,8 @@ var packageCopyCmd = &cobra.Command{
 	Short: "copy package",
 	Long:  `Copies a package.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -44,6 +48,8 @@ var packageEditCmd = &cobra.Command{
 	Short: "edit package",
 	Long:  `Edits a package.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -54,6 +60,8 @@ var packageFindCmd = &cobra.Command{
 	Short: "find package",
 	Long:  `Finds a given package.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -64,6 +72,8 @@ var packageListCmd = &cobra.Command{
 	Short: "list all packages",
 	Long:  `Lists all available packages.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -74,6 +84,8 @@ var packageRemoveCmd = &cobra.Command{
 	Short: "remove package",
 	Long:  `Removes a given package.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -84,6 +96,8 @@ var packageRenameCmd = &cobra.Command{
 	Short: "rename package",
 	Long:  `Renames a given package.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -94,6 +108,8 @@ var packageReportCmd = &cobra.Command{
 	Short: "list all packages in detail",
 	Long:  `Shows detailed information about all packages.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -31,6 +31,7 @@ var profileAddCmd = &cobra.Command{
 	Short: "add profile",
 	Long:  `Adds a profile.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		var newProfile cobbler.Profile
 		// internal fields (ctime, mtime, uid, depth, repos-enabled) cannot be modified
@@ -81,6 +82,8 @@ var profileCopyCmd = &cobra.Command{
 	Short: "copy profile",
 	Long:  `Copies a profile.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -91,6 +94,8 @@ var profileDumpVarsCmd = &cobra.Command{
 	Short: "dump profile variables",
 	Long:  `Prints all profile variables to stdout.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -101,6 +106,7 @@ var profileEditCmd = &cobra.Command{
 	Short: "edit profile",
 	Long:  `Edits a profile.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		// find profile through its name
 		pname, _ := cmd.Flags().GetString("name")
@@ -256,6 +262,8 @@ var profileFindCmd = &cobra.Command{
 	Short: "find profile",
 	Long:  `Finds a given profile.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -266,6 +274,8 @@ var profileGetAutoinstallCmd = &cobra.Command{
 	Short: "dump autoinstall XML",
 	Long:  `Prints the autoinstall XML file of the given profile to stdout.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -276,6 +286,7 @@ var profileListCmd = &cobra.Command{
 	Short: "list all profiles",
 	Long:  `Lists all available profiles.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		profiles, err = Client.GetDistros()
 
@@ -293,6 +304,7 @@ var profileRemoveCmd = &cobra.Command{
 	Short: "remove profile",
 	Long:  `Removes a given profile.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		pname, _ := cmd.Flags().GetString("name")
 		err := Client.DeleteProfile(pname)
@@ -308,6 +320,8 @@ var profileRenameCmd = &cobra.Command{
 	Short: "rename profile",
 	Long:  `Renames a given profile.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -318,6 +332,8 @@ var profileReportCmd = &cobra.Command{
 	Short: "list all profiles in detail",
 	Long:  `Shows detailed information about all profiles.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},

--- a/cmd/replicate.go
+++ b/cmd/replicate.go
@@ -19,6 +19,7 @@ relevant cobbler.conf and modules.conf, as these files are not synced.
 See https://cobbler.readthedocs.io/en/latest/cobbler.html#cobbler-replicate for more information.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 		// TODO: call cobblerclient
 	},
 }

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -32,6 +32,7 @@ var repoAddCmd = &cobra.Command{
 	Short: "add repository",
 	Long:  `Adds a repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		var newRepo cobbler.Repo
 
@@ -68,6 +69,8 @@ var repoAutoAddCmd = &cobra.Command{
 	Short: "add repository automatically",
 	Long:  `Automatically adds a repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -78,6 +81,8 @@ var repoCopyCmd = &cobra.Command{
 	Short: "copy repository",
 	Long:  `Copies a repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -88,6 +93,7 @@ var repoEditCmd = &cobra.Command{
 	Short: "edit repository",
 	Long:  `Edits a repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		// find repo through its name
 		rname, _ := cmd.Flags().GetString("name")
@@ -174,6 +180,8 @@ var repoFindCmd = &cobra.Command{
 	Short: "find repository",
 	Long:  `Finds a given repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -184,6 +192,7 @@ var repoListCmd = &cobra.Command{
 	Short: "list all repositorys",
 	Long:  `Lists all available repositories.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		repos, err = Client.GetRepos()
 
@@ -200,6 +209,7 @@ var repoRemoveCmd = &cobra.Command{
 	Short: "remove repository",
 	Long:  `Removes a given repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		rname, _ := cmd.Flags().GetString("name")
 		err := Client.DeleteRepo(rname)
@@ -214,6 +224,8 @@ var repoRenameCmd = &cobra.Command{
 	Short: "rename repository",
 	Long:  `Renames a given repository.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -224,6 +236,8 @@ var repoReportCmd = &cobra.Command{
 	Short: "list all repositorys in detail",
 	Long:  `Shows detailed information about all repositories.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -17,6 +17,8 @@ most of the other Cobbler commands (currently: distro, profile, system, repo, im
 Identical to 'cobbler list'`,
 
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 	},
 }

--- a/cmd/reposync.go
+++ b/cmd/reposync.go
@@ -17,6 +17,8 @@ var reposyncCmd = &cobra.Command{
 See https://cobbler.readthedocs.io/en/latest/cobbler.html#cobbler-reposync for more information.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,7 +68,6 @@ func initConfig() {
 		// TODO: Do we need the output what config file is used?
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
-	generateCobblerClient()
 }
 
 func checkError(err error) error {

--- a/cmd/setting.go
+++ b/cmd/setting.go
@@ -23,6 +23,8 @@ var settingEditCmd = &cobra.Command{
 	Short: "edit settings",
 	Long:  `Edits the settings.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -33,6 +35,8 @@ var settingReportCmd = &cobra.Command{
 	Short: "list settings",
 	Long:  `Prints settings to stdout.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},

--- a/cmd/signature.go
+++ b/cmd/signature.go
@@ -14,6 +14,7 @@ var signatureCmd = &cobra.Command{
 	Short: "Signature management",
 	Long:  `Reloads, reports or updates the signatures of the distinct operating system versions.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		// cmd.Help() this should be used once the library is implemented
 		// TODO: call cobblerclient

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -18,6 +18,7 @@ changed behind the scenes. It brings the filesystem up to date with the configur
 
 See https://cobbler.readthedocs.io/en/latest/cobbler.html#cobbler-sync for more information.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		// not fully implemented in the cobblerclient library. You cannot use flags at the moment!
 		Client.Sync()

--- a/cmd/system.go
+++ b/cmd/system.go
@@ -33,6 +33,7 @@ var systemAddCmd = &cobra.Command{
 	Short: "add system",
 	Long:  `Adds a system.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		var newSystem cobbler.System
 
@@ -121,6 +122,8 @@ var systemCopyCmd = &cobra.Command{
 	Short: "copy system",
 	Long:  `Copies a system.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -131,6 +134,8 @@ var systemDumpVarsCmd = &cobra.Command{
 	Short: "dump system variables",
 	Long:  `Prints all system variables to stdout.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -141,6 +146,7 @@ var systemEditCmd = &cobra.Command{
 	Short: "edit system",
 	Long:  `Edits a system.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		// find profile through its name
 		pname, _ := cmd.Flags().GetString("name")
@@ -329,6 +335,8 @@ var systemFindCmd = &cobra.Command{
 	Short: "find system",
 	Long:  `Finds a given system.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -339,6 +347,8 @@ var systemGetAutoinstallCmd = &cobra.Command{
 	Short: "dump autoinstall XML",
 	Long:  `Prints the autoinstall XML file of the given system to stdout.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -349,6 +359,7 @@ var systemListCmd = &cobra.Command{
 	Short: "list all systems",
 	Long:  `Lists all available systems.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		systems, err = Client.GetSystems()
 
@@ -366,6 +377,8 @@ var systemPowerOffCmd = &cobra.Command{
 	Short: "power off system",
 	Long:  `Powers off the selected system.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -376,6 +389,8 @@ var systemPowerOnCmd = &cobra.Command{
 	Short: "power on system",
 	Long:  `Powers on the selected system.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -386,6 +401,8 @@ var systemPowerStatusCmd = &cobra.Command{
 	Short: "Power status of the system",
 	Long:  `Querys the power status of the selected system.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -396,6 +413,8 @@ var systemRebootCmd = &cobra.Command{
 	Short: "reboot system",
 	Long:  `Reboots the selected system.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -406,6 +425,7 @@ var systemRemoveCmd = &cobra.Command{
 	Short: "remove system",
 	Long:  `Removes a given system.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 
 		sname, _ := cmd.Flags().GetString("name")
 		err := Client.DeleteSystem(sname)
@@ -421,6 +441,8 @@ var systemRenameCmd = &cobra.Command{
 	Short: "rename system",
 	Long:  `Renames a given system.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},
@@ -431,6 +453,8 @@ var systemReportCmd = &cobra.Command{
 	Short: "list all systems in detail",
 	Long:  `Shows detailed information about all systems.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 		notImplemented()
 	},

--- a/cmd/validateAutoinstalls.go
+++ b/cmd/validateAutoinstalls.go
@@ -14,6 +14,7 @@ var validateAutoinstallsCmd = &cobra.Command{
 	Short: "Autoinstall validation",
 	Long:  `Validates the autoinstall files.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
 		// TODO: call cobblerclient
 	},
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -14,6 +14,8 @@ var versionCmd = &cobra.Command{
 	Short: "Print the Cobbler version",
 	Long:  `Shows the Cobbler server version.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		generateCobblerClient()
+
 		// TODO: call cobblerclient
 	},
 }


### PR DESCRIPTION
This is needed so when executing --help or generating the shell completion no login is attempted to be performed.

Fixes #42

Building the project can be now done without the exit status 1:

```
enno@dell-laptop ~/S/G/cobbler-cli (main)> make build
building package
go build -o cobbler main.go
creating shell completions
make shell_completions
make[1]: Verzeichnis „/home/enno/Sources/GolandProjects/cobbler-cli“ wird betreten
./cobbler completion bash > config/completions/bash/cobbler
./cobbler completion fish > config/completions/fish/cobbler
./cobbler completion powershell > config/completions/powershell/cobbler
./cobbler completion zsh > config/completions/zsh/cobbler
make[1]: Verzeichnis „/home/enno/Sources/GolandProjects/cobbler-cli“ wird verlassen
```