### PR TITLE
Docker: Add image-based variant of the CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,50 @@ permissions:
   contents: write
 
 jobs:
+  push_to_registry:
+    name: Push Docker image to GHCR
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+      PUSH_IMAGE: ${{ startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' }}
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        # https://github.com/docker/metadata-action
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        # https://github.com/docker/build-push-action
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./packaging/docker/Dockerfile
+          push: ${{ env.PUSH_IMAGE }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        # https://github.com/actions/attest-build-provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: ${{ env.PUSH_IMAGE }}
   goreleaser:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 BINARY_NAME=cobbler
+EXECUTOR?=docker
 
 build:
 	@echo "building package"
 	go build -o ${BINARY_NAME} main.go
 	@echo "creating shell completions"
 	make shell_completions
+
+build-docker:
+	@echo "building docker"
+	${EXECUTOR} build -t cobbler/cli:latest -f packaging/docker/Dockerfile .
 
 clean:
 	go clean

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ communication with a Cobbler server.
    :numbered:
 
    Quickstart Guide <quickstart-guide>
+   Installing <install>
 
 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,0 +1,42 @@
+*************************************
+Installing the Cobbler standalone CLI
+*************************************
+
+.. note::
+   Before version 1.0 is released, expect information on this page to be a WIP.
+
+.. warning::
+   The standalone Cobbler CLI will conflict with the bundled CLI of the Cobbler daemon with version 3.3.x and older.
+
+RPM
+###
+
+#. Add the OBS Repository for your operating system
+#. Enable and refresh the previously added repository
+#. Install the binary package ``cobbler-cli``
+
+DEB
+###
+
+#. Add the OBS Repository for your operating system
+#. Enable and refresh the previously added repository
+#. Install the binary package ``cobbler-cli``
+
+Docker
+######
+
+.. code-block:: shell-session
+
+   docker run --rm ghcr.io/cobbler/cli:latest
+
+
+.. code-block:: shell-session
+
+   podman run --rm ghcr.io/cobbler/cli:latest
+
+Source
+######
+
+.. code-block:: shell-session
+
+   make build

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.22
+
+WORKDIR /usr/src/app
+
+# pre-copy/cache go.mod for pre-downloading dependencies and only redownloading them in subsequent builds if they change
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY . .
+RUN go build -v -o /usr/local/bin/cobbler ./main.go
+
+ENTRYPOINT ["cobbler"]
+CMD ["cobbler"]


### PR DESCRIPTION
Fixes #54 

This PR adds the following things:

- Dockerfile to ship an OCI variant of the application
- CI changes to build on PRs and publish to latest versions and tags
- Basic documentation on how to use the container image