### PR TITLE
Event: Add command to read and list events

### DIFF
--- a/cmd/event.go
+++ b/cmd/event.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-FileCopyrightText: 2024 Enno Gotthold <egotthold@suse.com>
+// SPDX-FileCopyrightText: Copyright SUSE LLC
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"time"
+)
+
+var eventCmd = &cobra.Command{
+	Use:   "event",
+	Short: "Show and query events for their status.",
+	Run: func(cmd *cobra.Command, args []string) {
+		_ = cmd.Help()
+	},
+}
+
+var eventStatusCmd = &cobra.Command{
+	Use: "status",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		generateCobblerClient()
+
+		eventId, err := cmd.Flags().GetString("event-id")
+		if err != nil {
+			return err
+		}
+
+		event, err := Client.GetTaskStatus(eventId)
+		if err != nil {
+			return err
+		}
+		fmt.Println(event.State)
+		return nil
+	},
+}
+
+var eventListCmd = &cobra.Command{
+	Use: "list",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		generateCobblerClient()
+
+		user, err := cmd.Flags().GetString("user")
+		if err != nil {
+			return err
+		}
+
+		events, err := Client.GetEvents(user)
+		if err != nil {
+			return err
+		}
+		idWidth := 0
+		stateWidth := 10
+		stateTimeWidth := 24 // Fixed width
+		nameWidth := 0
+		for _, event := range events {
+			if len(event.ID) > idWidth {
+				idWidth = len(event.ID)
+			}
+			if len(event.Name) > nameWidth {
+				nameWidth = len(event.Name)
+			}
+			if len(event.State) > stateWidth {
+				stateWidth = len(event.State)
+			}
+		}
+		fmt.Printf("%*s | %*s | %*s | %*s | %s \n", idWidth, "ID", nameWidth, "Name", stateWidth, "Task State", stateTimeWidth, "Time (last transitioned)", "Read by Who")
+		for _, event := range events {
+			stateTimeStruct, err := covertFloatToUtcTime(event.StateTime)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%*s | %*s | %*s | %*s | %s \n", idWidth, event.ID, nameWidth, event.Name, stateWidth, event.State, stateTimeWidth, stateTimeStruct.Format(time.DateTime), event.ReadByWho)
+		}
+		return nil
+	},
+}
+
+var eventLogCmd = &cobra.Command{
+	Use: "log",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		generateCobblerClient()
+
+		eventId, err := cmd.Flags().GetString("event-id")
+		if err != nil {
+			return err
+		}
+
+		eventLog, err := Client.GetEventLog(eventId)
+		if err != nil {
+			return err
+		}
+		fmt.Println(eventLog)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(eventCmd)
+
+	eventCmd.AddCommand(eventStatusCmd)
+	eventCmd.AddCommand(eventListCmd)
+	eventCmd.AddCommand(eventLogCmd)
+
+	// local flags for status
+	eventStatusCmd.Flags().String("event-id", "", "the event ID of the background task")
+	_ = eventStatusCmd.MarkFlagRequired("event-id")
+
+	// local flags for list
+	eventListCmd.Flags().String("user", "", "giving this parameter will show only events the user hasn't seen yet")
+
+	// local flags for log
+	eventLogCmd.Flags().String("event-id", "", "the event ID of the background task")
+	_ = eventStatusCmd.MarkFlagRequired("event-id")
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cobbler/cli
 go 1.22
 
 require (
-	github.com/cobbler/cobblerclient v0.5.3
+	github.com/cobbler/cobblerclient v0.5.4
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cobbler/cobblerclient v0.5.3 h1:43STm8izD++BqHJIpxpYrHvNXXQvCtmcmlyO2gskNmg=
-github.com/cobbler/cobblerclient v0.5.3/go.mod h1:n6b8fTUOlg7BdMl6FeifUm4Uk1JY6/tlTlOClV4x2Wc=
+github.com/cobbler/cobblerclient v0.5.4 h1:ix+z9gwfUxv28ANz7giPGt4ICufR83rUm9E2q9dCwuw=
+github.com/cobbler/cobblerclient v0.5.4/go.mod h1:n6b8fTUOlg7BdMl6FeifUm4Uk1JY6/tlTlOClV4x2Wc=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Fixes #57 

This also updates the client to version 0.5.4.

Example outputs:

```
./cobbler --config .cobbler.yaml event list
                                                                                  ID |                              Name | Task State | Time (last transitioned) | Read by Who 
2024-10-29_094039_Create bootable bootloader images_a6eb18843eae4502a82d1f14bd2a8a80 | Create bootable bootloader images |   complete |      2024-10-29 09:40:39 | [] 
                             2024-10-29_103248_Sync_a9a067f2343641ae8af13fbfc5977e5a |                              Sync |   complete |      2024-10-29 10:32:48 | [
```

```
./cobbler --config .cobbler.yaml event status --event-id="2024-10-29_094039_Create bootable bootloader images_a6eb18843eae4502a82d1f14bd2a8a80"
complete
```

```
./cobbler --config .cobbler.yaml event log --event-id="2024-10-29_094039_Create bootable bootloader images_a6eb18843eae4502a82d1f14bd2a8a80"
[2024-10-29_094039_Create bootable bootloader images_a6eb18843eae4502a82d1f14bd2a8a80] 2024-10-29 09:40:39,886 - INFO | start_task(mkloaders); event_id(2024-10-29_094039_Create bootable bootloader images_a6eb18843eae4502a82d1f14bd2a8a80)
[2024-10-29_094039_Create bootable bootloader images_a6eb18843eae4502a82d1f14bd2a8a80] 2024-10-29 09:40:39,900 - INFO | syslinux version 4 detected! Skip making symlink of "ldlinux.c32" file!
[2024-10-29_094039_Create bootable bootloader images_a6eb18843eae4502a82d1f14bd2a8a80] 2024-10-29 09:40:39,901 - INFO | GRUB2 modules directory for arch "aarch64" did no exist. Skipping GRUB2 creation
[2024-10-29_094039_Create bootable bootloader images_a6eb18843eae4502a82d1f14bd2a8a80] 2024-10-29 09:40:39,901 - INFO | GRUB2 modules directory for arch "arm" did no exist. Skipping GRUB2 creation
[2024-10-29_094039_Create bootable bootloader images_a6eb18843eae4502a82d1f14bd2a8a80] 2024-10-29 09:40:39,947 - INFO | Successfully built bootloader for arch "arm64-efi"!
[2024-10-29_094039_Create bootable bootloader images_a6eb18843eae4502a82d1f14bd2a8a80] 2024-10-29 09:40:39,947 - INFO | GRUB2 modules directory for arch "i386-efi" did no exist. Skipping GRUB2 creation
[2024-10-29_094039_Create bootable bootloader images_a6eb18843eae4502a82d1f14bd2a8a80] 2024-10-29 09:40:40,217 - INFO | Successfully built bootloader for arch "i386-pc-pxe"!
[2024-10-29_094039_Create bootable bootloader images_a6eb18843eae4502a82d1f14bd2a8a80] 2024-10-29 09:40:40,217 - INFO | GRUB2 modules directory for arch "i686" did no exist. Skipping GRUB2 creation
[2024-10-29_094039_Create bootable bootloader images_a6eb18843eae4502a82d1f14bd2a8a80] 2024-10-29 09:40:40,217 - INFO | GRUB2 modules directory for arch "IA64" did no exist. Skipping GRUB2 creation
[2024-10-29_094039_Create bootable bootloader images_a6eb18843eae4502a82d1f14bd2a8a80] 2024-10-29 09:40:40,217 - INFO | GRUB2 modules directory for arch "powerpc-ieee1275" did no exist. Skipping GRUB2 creation
[2024-10-29_094039_Create bootable bootloader images_a6eb18843eae4502a82d1f14bd2a8a80] 2024-10-29 09:40:40,262 - INFO | Successfully built bootloader for arch "x86_64-efi"!
[2024-10-29_094039_Create bootable bootloader images_a6eb18843eae4502a82d1f14bd2a8a80] 2024-10-29 09:40:40,262 - INFO | ### TASK COMPLETE ###
```