### PR TITLE
Add "status" command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,6 +64,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(NewRepoSyncCmd())
 	rootCmd.AddCommand(NewSettingCmd())
 	rootCmd.AddCommand(NewSignatureCmd())
+	rootCmd.AddCommand(NewStatusCmd())
 	rootCmd.AddCommand(NewSyncCmd())
 	rootCmd.AddCommand(NewSystemCmd())
 	rootCmd.AddCommand(NewValidateAutoinstallsCmd())

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+	cobbler "github.com/cobbler/cobblerclient"
+	"github.com/spf13/cobra"
+)
+
+func NewStatusCmd() *cobra.Command {
+	statusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "View installation status of Cobbler Profiles and Systems.",
+		Long: `This command displays the current status of all Cobbler Profiles and Systems. All installations that
+run for longer then 100 minutes are considered stalled.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := generateCobblerClient()
+			if err != nil {
+				return err
+			}
+
+			res, err := Client.GetStatus(cobbler.StatusText)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), res.(string))
+
+			return nil
+		},
+	}
+	return statusCmd
+}

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"bytes"
+	"github.com/cobbler/cobblerclient"
+	"github.com/spf13/cobra"
+	"testing"
+)
+
+func Test_StatusCmd(t *testing.T) {
+	// Arrange
+	cobra.OnInitialize(initConfig, setupLogger)
+	rootCmd := NewRootCmd()
+	rootCmd.SetArgs([]string{"--config", "../testing/.cobbler.yaml", "status"})
+	stdout := bytes.NewBufferString("")
+	stderr := bytes.NewBufferString("")
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(stderr)
+	expectedResult := "ip             |target              |start            |state            \n"
+
+	// Act
+	err := rootCmd.Execute()
+
+	// Assert
+	cobblerclient.FailOnError(t, err)
+	FailOnNonEmptyStream(t, stderr)
+	if stdout.String() != expectedResult {
+		t.Errorf(`Expected "%s", got "%s"`, expectedResult, stdout.String())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cobbler/cli
 go 1.22
 
 require (
-	github.com/cobbler/cobblerclient v0.5.5
+	github.com/cobbler/cobblerclient v0.5.7
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cobbler/cobblerclient v0.5.5 h1:sMd+j3IcW8atuAbwiJWOL+vriqxTPi5jxEg10TdQUc0=
-github.com/cobbler/cobblerclient v0.5.5/go.mod h1:n6b8fTUOlg7BdMl6FeifUm4Uk1JY6/tlTlOClV4x2Wc=
+github.com/cobbler/cobblerclient v0.5.7 h1:0G/lvlmssCCpV8MiuqcOlL1P2BwwHh+V05aF3vHnr6k=
+github.com/cobbler/cobblerclient v0.5.7/go.mod h1:n6b8fTUOlg7BdMl6FeifUm4Uk1JY6/tlTlOClV4x2Wc=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Fixes #61 

This outputs the server-side generated output in text mode.

Edit: There is a backend bug that I need to report which causes the generation to fail if logrotate compressed files with `xz`. This issue is visible in the CLI but not fixable on the CLI side.