### PR TITLE
Fix dependabot with goreleaser

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -114,6 +114,7 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: ${{ env.PUSH_IMAGE }}
   goreleaser:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     needs:
       - native

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,6 @@ jobs:
           go-version: stable
       - name: golangci-lint
         # https://github.com/golangci/golangci-lint-action
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v1.64.5
+          version: v2.9.0

--- a/cmd/aclsetup.go
+++ b/cmd/aclsetup.go
@@ -47,7 +47,7 @@ func NewAclSetupCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "Event ID: ", eventId)
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Event ID: ", eventId)
 			return nil
 		},
 	}

--- a/cmd/buildiso.go
+++ b/cmd/buildiso.go
@@ -77,7 +77,7 @@ func NewBuildisoCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
 			return nil
 		},
 	}

--- a/cmd/distro.go
+++ b/cmd/distro.go
@@ -322,7 +322,7 @@ func NewDistroAddCmd() (*cobra.Command, error) {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Distro %s created\n", distro.Name)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Distro %s created\n", distro.Name)
 			return nil
 		},
 	}
@@ -570,7 +570,7 @@ func reportDistros(cmd *cobra.Command, distroNames []string) error {
 			return err
 		}
 		printStructured(cmd, distro)
-		fmt.Fprintln(cmd.OutOrStdout(), "")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 	}
 	return nil
 }
@@ -656,15 +656,15 @@ func NewDistroExportCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					fmt.Fprintln(cmd.OutOrStdout(), string(jsonDocument))
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(jsonDocument))
 				}
 				if formatOption == "yaml" {
 					yamlDocument, err := yaml.Marshal(distro)
 					if err != nil {
 						return err
 					}
-					fmt.Fprintln(cmd.OutOrStdout(), "---")
-					fmt.Fprintln(cmd.OutOrStdout(), string(yamlDocument))
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "---")
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(yamlDocument))
 				}
 			}
 			return nil

--- a/cmd/distro_group.go
+++ b/cmd/distro_group.go
@@ -57,7 +57,7 @@ func newDistroGroupAddCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Distro group %s created\n", created.Name)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Distro group %s created\n", created.Name)
 			return nil
 		},
 	}
@@ -233,7 +233,7 @@ func newDistroGroupReportCmd() *cobra.Command {
 					return err
 				}
 				printStructured(cmd, g)
-				fmt.Fprintln(cmd.OutOrStdout(), "")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 			}
 			return nil
 		},

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -42,7 +42,7 @@ func NewEventStatusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), event.State)
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), event.State)
 			return nil
 		},
 	}
@@ -84,13 +84,13 @@ func NewEventListCmd() *cobra.Command {
 					stateWidth = len(event.State)
 				}
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "%*s | %*s | %*s | %*s | %s \n", idWidth, "ID", nameWidth, "Name", stateWidth, "Task State", stateTimeWidth, "Time (last transitioned)", "Read by Who")
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%*s | %*s | %*s | %*s | %s \n", idWidth, "ID", nameWidth, "Name", stateWidth, "Task State", stateTimeWidth, "Time (last transitioned)", "Read by Who")
 			for _, event := range events {
 				stateTimeStruct, err := covertFloatToUtcTime(event.StateTime)
 				if err != nil {
 					return err
 				}
-				fmt.Fprintf(cmd.OutOrStdout(), "%*s | %*s | %*s | %*s | %s \n", idWidth, event.ID, nameWidth, event.Name, stateWidth, event.State, stateTimeWidth, stateTimeStruct.Format(time.DateTime), event.ReadByWho)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%*s | %*s | %*s | %*s | %s \n", idWidth, event.ID, nameWidth, event.Name, stateWidth, event.State, stateTimeWidth, stateTimeStruct.Format(time.DateTime), event.ReadByWho)
 			}
 			return nil
 		},
@@ -117,7 +117,7 @@ func NewEventLogCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), eventLog)
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), eventLog)
 			return nil
 		},
 	}

--- a/cmd/group_common.go
+++ b/cmd/group_common.go
@@ -55,14 +55,14 @@ func writeExport(cmd *cobra.Command, format string, v interface{}) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
 	case "yaml":
 		out, err := yaml.Marshal(v)
 		if err != nil {
 			return err
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), "---")
-		fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "---")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
 	default:
 		return fmt.Errorf("format must be json or yaml")
 	}

--- a/cmd/hardlink.go
+++ b/cmd/hardlink.go
@@ -25,7 +25,7 @@ func NewHardlinkCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
 			return nil
 		},
 	}

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -341,7 +341,7 @@ func NewImageAddCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Image %s created\n", system.Name)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Image %s created\n", system.Name)
 			return nil
 		},
 	}
@@ -569,7 +569,7 @@ func reportImages(cmd *cobra.Command, imageNames []string) error {
 			return err
 		}
 		printStructured(cmd, system)
-		fmt.Fprintln(cmd.OutOrStdout(), "")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 	}
 	return nil
 }
@@ -655,15 +655,15 @@ func NewImageExportCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					fmt.Fprintln(cmd.OutOrStdout(), string(jsonDocument))
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(jsonDocument))
 				}
 				if formatOption == "yaml" {
 					yamlDocument, err := yaml.Marshal(image)
 					if err != nil {
 						return err
 					}
-					fmt.Fprintln(cmd.OutOrStdout(), "---")
-					fmt.Fprintln(cmd.OutOrStdout(), string(yamlDocument))
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "---")
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(yamlDocument))
 				}
 			}
 			return nil

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -70,7 +70,7 @@ See https://cobbler.readthedocs.io/en/latest/quickstart-guide.html#importing-you
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
 			return nil
 		},
 	}

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -196,7 +196,7 @@ func NewInterfaceAddCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Network interface %s created\n", created.Name)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Network interface %s created\n", created.Name)
 			return nil
 		},
 	}
@@ -368,9 +368,9 @@ func NewInterfaceListCommand() *cobra.Command {
 			for _, systemName := range systemNames {
 				ifaceNames := grouped[systemName]
 				sort.Strings(ifaceNames)
-				fmt.Fprintf(cmd.OutOrStdout(), "%s:\n", systemName)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s:\n", systemName)
 				for _, n := range ifaceNames {
-					fmt.Fprintf(cmd.OutOrStdout(), "    %s\n", n)
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    %s\n", n)
 				}
 			}
 			return nil
@@ -419,7 +419,7 @@ func NewInterfaceReportCommand() *cobra.Command {
 			}
 			for _, iface := range interfaces {
 				printStructured(cmd, iface)
-				fmt.Fprintln(cmd.OutOrStdout(), "")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 			}
 			return nil
 		},
@@ -489,14 +489,14 @@ func NewInterfaceExportCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					fmt.Fprintln(cmd.OutOrStdout(), string(out))
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
 				case "yaml":
 					out, err := yaml.Marshal(iface)
 					if err != nil {
 						return err
 					}
-					fmt.Fprintln(cmd.OutOrStdout(), "---")
-					fmt.Fprintln(cmd.OutOrStdout(), string(out))
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "---")
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
 				}
 			}
 			return nil

--- a/cmd/item.go
+++ b/cmd/item.go
@@ -138,7 +138,7 @@ func FindItemNames(cmd *cobra.Command, args []string, what string) error {
 		case "config", "page", "items-per-page":
 			return
 		}
-		key := strings.Replace(flag.Name, "-", "_", -1)
+		key := strings.ReplaceAll(flag.Name, "-", "_")
 		criteria[key] = flag.Value.String()
 	})
 
@@ -153,13 +153,13 @@ func FindItemNames(cmd *cobra.Command, args []string, what string) error {
 		for _, raw := range result.FoundItems {
 			if asMap, ok := raw.(map[string]interface{}); ok {
 				if name, ok := asMap["name"].(string); ok {
-					fmt.Fprintln(cmd.OutOrStdout(), name)
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), name)
 					continue
 				}
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), raw)
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), raw)
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "# page %d of %d (%d total)\n",
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "# page %d of %d (%d total)\n",
 			result.PageInfo.Page, result.PageInfo.NumPages, result.PageInfo.NumItems)
 		return nil
 	}
@@ -169,7 +169,7 @@ func FindItemNames(cmd *cobra.Command, args []string, what string) error {
 		return err
 	}
 	for _, name := range itemNames {
-		fmt.Fprintln(cmd.OutOrStdout(), name)
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), name)
 	}
 	return nil
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -62,10 +62,10 @@ Identical to 'cobbler report'`,
 }
 
 func listItems(cmd *cobra.Command, what string, items []string) {
-	fmt.Fprintf(cmd.OutOrStdout(), "%s:\n", what)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s:\n", what)
 	sort.Strings(items)
 	for _, item := range items {
-		fmt.Fprintf(cmd.OutOrStdout(), "   %s\n", item)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   %s\n", item)
 	}
-	fmt.Fprintln(cmd.OutOrStdout(), "")
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 }

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -31,7 +31,7 @@ func Test_ListCmd(t *testing.T) {
 		t.Fatal(err)
 	}
 	stdoutString := string(stdoutBytes)
-	if !(strings.Contains(stdoutString, "distros:") && strings.Contains(stdoutString, "profiles")) {
+	if !strings.Contains(stdoutString, "distros:") || !strings.Contains(stdoutString, "profiles") {
 		fmt.Println(stdoutString)
 		t.Fatal("no heading for distros and profiles present")
 	}

--- a/cmd/menu.go
+++ b/cmd/menu.go
@@ -116,7 +116,7 @@ func NewMenuAddCmd() (*cobra.Command, error) {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Menu %s created\n", menu.Name)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Menu %s created\n", menu.Name)
 			return nil
 		},
 	}
@@ -341,7 +341,7 @@ func reportMenus(cmd *cobra.Command, menuNames []string) error {
 			return err
 		}
 		printStructured(cmd, menu)
-		fmt.Fprintln(cmd.OutOrStdout(), "")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 	}
 	return nil
 }
@@ -427,15 +427,15 @@ func NewMenuExportCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					fmt.Fprintln(cmd.OutOrStdout(), string(jsonDocument))
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(jsonDocument))
 				}
 				if formatOption == "yaml" {
 					yamlDocument, err := yaml.Marshal(menu)
 					if err != nil {
 						return err
 					}
-					fmt.Fprintln(cmd.OutOrStdout(), "---")
-					fmt.Fprintln(cmd.OutOrStdout(), string(yamlDocument))
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "---")
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(yamlDocument))
 				}
 			}
 			return nil

--- a/cmd/mkloaders.go
+++ b/cmd/mkloaders.go
@@ -28,7 +28,7 @@ The options are configured in the Cobbler settings file.`,
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
 			return nil
 		},
 	}

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -455,7 +455,7 @@ func NewProfileAddCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Profile %s created\n", profile.Name)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Profile %s created\n", profile.Name)
 			return nil
 		},
 	}
@@ -648,14 +648,14 @@ func NewProfileGetAutoinstallCmd() *cobra.Command {
 				return err
 			}
 			if !profileExists {
-				return fmt.Errorf("Profile does not exist!")
+				return fmt.Errorf("profile does not exist")
 
 			}
 			autoinstallRendered, err := Client.GenerateAutoinstall(profileName, "profile", "name", "", "")
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), autoinstallRendered)
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), autoinstallRendered)
 			return nil
 		},
 	}
@@ -773,7 +773,7 @@ func reportProfiles(cmd *cobra.Command, profileNames []string) error {
 			return err
 		}
 		printStructured(cmd, profile)
-		fmt.Fprintln(cmd.OutOrStdout(), "")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 	}
 	return nil
 }
@@ -859,15 +859,15 @@ func NewProfileExportCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					fmt.Fprintln(cmd.OutOrStdout(), string(jsonDocument))
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(jsonDocument))
 				}
 				if formatOption == "yaml" {
 					yamlDocument, err := yaml.Marshal(profile)
 					if err != nil {
 						return err
 					}
-					fmt.Fprintln(cmd.OutOrStdout(), "---")
-					fmt.Fprintln(cmd.OutOrStdout(), string(yamlDocument))
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "---")
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(yamlDocument))
 				}
 			}
 			return nil

--- a/cmd/profile_group.go
+++ b/cmd/profile_group.go
@@ -57,7 +57,7 @@ func newProfileGroupAddCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Profile group %s created\n", created.Name)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Profile group %s created\n", created.Name)
 			return nil
 		},
 	}
@@ -233,7 +233,7 @@ func newProfileGroupReportCmd() *cobra.Command {
 					return err
 				}
 				printStructured(cmd, g)
-				fmt.Fprintln(cmd.OutOrStdout(), "")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 			}
 			return nil
 		},

--- a/cmd/replicate.go
+++ b/cmd/replicate.go
@@ -88,7 +88,7 @@ See https://cobbler.readthedocs.io/en/latest/cobbler.html#cobbler-replicate for 
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
 			return nil
 		},
 	}

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -224,7 +224,7 @@ func NewRepoAddCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Repo %s created\n", repo.Name)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Repo %s created\n", repo.Name)
 			return nil
 		},
 	}
@@ -476,7 +476,7 @@ func reportRepos(cmd *cobra.Command, repoNames []string) error {
 			return err
 		}
 		printStructured(cmd, repo)
-		fmt.Fprintln(cmd.OutOrStdout(), "")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 	}
 	return nil
 }
@@ -562,15 +562,15 @@ func NewRepoExportCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					fmt.Fprintln(cmd.OutOrStdout(), string(jsonDocument))
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(jsonDocument))
 				}
 				if formatOption == "yaml" {
 					yamlDocument, err := yaml.Marshal(repo)
 					if err != nil {
 						return err
 					}
-					fmt.Fprintln(cmd.OutOrStdout(), "---")
-					fmt.Fprintln(cmd.OutOrStdout(), string(yamlDocument))
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "---")
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(yamlDocument))
 				}
 			}
 			return nil

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -25,8 +25,8 @@ Identical to 'cobbler list'`,
 			}
 
 			// Distro
-			fmt.Fprintln(cmd.OutOrStdout(), "distros:")
-			fmt.Fprintln(cmd.OutOrStdout(), "==========")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "distros:")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "==========")
 			distroNames, err := Client.ListDistroNames()
 			if err != nil {
 				return err
@@ -35,11 +35,11 @@ Identical to 'cobbler list'`,
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 
 			// Profile
-			fmt.Fprintln(cmd.OutOrStdout(), "profiles:")
-			fmt.Fprintln(cmd.OutOrStdout(), "==========")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "profiles:")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "==========")
 			profileNames, err := Client.ListProfileNames()
 			if err != nil {
 				return err
@@ -48,11 +48,11 @@ Identical to 'cobbler list'`,
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 
 			// System
-			fmt.Fprintln(cmd.OutOrStdout(), "systems:")
-			fmt.Fprintln(cmd.OutOrStdout(), "==========")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "systems:")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "==========")
 			systemNames, err := Client.ListSystemNames()
 			if err != nil {
 				return err
@@ -61,11 +61,11 @@ Identical to 'cobbler list'`,
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 
 			// Repository
-			fmt.Fprintln(cmd.OutOrStdout(), "repos:")
-			fmt.Fprintln(cmd.OutOrStdout(), "==========")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "repos:")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "==========")
 			repoNames, err := Client.ListRepoNames()
 			if err != nil {
 				return err
@@ -74,11 +74,11 @@ Identical to 'cobbler list'`,
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 
 			// Image
-			fmt.Fprintln(cmd.OutOrStdout(), "images:")
-			fmt.Fprintln(cmd.OutOrStdout(), "==========")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "images:")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "==========")
 			imageNames, err := Client.ListImageNames()
 			if err != nil {
 				return err
@@ -87,11 +87,11 @@ Identical to 'cobbler list'`,
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 
 			// Menu
-			fmt.Fprintln(cmd.OutOrStdout(), "menus:")
-			fmt.Fprintln(cmd.OutOrStdout(), "==========")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "menus:")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "==========")
 			menuNames, err := Client.ListMenuNames()
 			if err != nil {
 				return err
@@ -100,7 +100,7 @@ Identical to 'cobbler list'`,
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 			return nil
 		},
 	}

--- a/cmd/report_test.go
+++ b/cmd/report_test.go
@@ -31,7 +31,7 @@ func Test_ReportCmd(t *testing.T) {
 		t.Fatal(err)
 	}
 	stdoutString := string(stdoutBytes)
-	if !(strings.Contains(stdoutString, "distros:") && strings.Contains(stdoutString, "profiles")) {
+	if !strings.Contains(stdoutString, "distros:") || !strings.Contains(stdoutString, "profiles") {
 		fmt.Println(stdoutString)
 		t.Fatal("no heading for distros and profiles present")
 	}

--- a/cmd/reposync.go
+++ b/cmd/reposync.go
@@ -47,7 +47,7 @@ See https://cobbler.readthedocs.io/en/latest/cobbler.html#cobbler-reposync for m
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
 			return nil
 		},
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -211,7 +211,7 @@ func printValueStructured(cmd *cobra.Command, name string, value reflect.Value) 
 
 func printNetworkInterfaces(cmd *cobra.Command, networkInterfaces map[string]*cobbler.NetworkInterface) {
 	for interfaceName, interfaceStruct := range networkInterfaces {
-		fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %s\n", "Interface =====", interfaceName)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %s\n", "Interface =====", interfaceName)
 		printStructured(cmd, interfaceStruct)
 	}
 }
@@ -221,46 +221,46 @@ func printField(cmd *cobra.Command, valueType reflect.Kind, name string, value i
 		time, err := covertFloatToUtcTime(value.(float64))
 		if err == nil {
 			// If there is an error just show the float
-			fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %s\n", name, time)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %s\n", name, time)
 			return
 		}
 	}
 	switch valueType {
 	case reflect.Bool:
-		fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %t\n", name, value.(bool))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %t\n", name, value.(bool))
 	case reflect.Int64:
-		fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %d\n", name, value.(int64))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %d\n", name, value.(int64))
 	case reflect.Int32:
-		fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %d\n", name, value.(int32))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %d\n", name, value.(int32))
 	case reflect.Int16:
-		fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %d\n", name, value.(int16))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %d\n", name, value.(int16))
 	case reflect.Int8:
-		fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %d\n", name, value.(int8))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %d\n", name, value.(int8))
 	case reflect.Int:
-		fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %d\n", name, value.(int))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %d\n", name, value.(int))
 	case reflect.Float32:
-		fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %f\n", name, value.(float32))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %f\n", name, value.(float32))
 	case reflect.Float64:
-		fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %f\n", name, value.(float64))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %f\n", name, value.(float64))
 	case reflect.Map:
 		res2B, _ := json.Marshal(value)
-		fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %s\n", name, string(res2B))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %s\n", name, string(res2B))
 	case reflect.Array, reflect.Slice:
 		arr := reflect.ValueOf(value)
-		fmt.Fprintf(cmd.OutOrStdout(), "%-40s: [", name)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-40s: [", name)
 		for i := 0; i < arr.Len(); i++ {
 			if i+1 != arr.Len() {
-				fmt.Fprintf(cmd.OutOrStdout(), "'%v', ", arr.Index(i).Interface())
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "'%v', ", arr.Index(i).Interface())
 			} else {
-				fmt.Fprintf(cmd.OutOrStdout(), "'%v'", arr.Index(i).Interface())
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "'%v'", arr.Index(i).Interface())
 			}
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "]\n")
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "]\n")
 	default:
 		if value == nil {
 			value = ""
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %s\n", name, value)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-40s: %s\n", name, value)
 		// fmt.Fprintf(cmd.OutOrStdout(),"%d: %s %s = %v\n", i, typeOfT.Field(i).Name, f.Type(), f.Interface())
 	}
 }

--- a/cmd/setting.go
+++ b/cmd/setting.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -46,19 +45,6 @@ func settingsFieldByMapstructureTag(settings *cobbler.Settings, name string) ref
 		}
 	}
 	return reflect.Value{}
-}
-
-// listSettingNames returns the known setting names sorted alphabetically.
-func listSettingNames(settings *cobbler.Settings) []string {
-	t := reflect.TypeOf(settings).Elem()
-	out := make([]string, 0, t.NumField())
-	for i := 0; i < t.NumField(); i++ {
-		if tag := t.Field(i).Tag.Get("mapstructure"); tag != "" {
-			out = append(out, tag)
-		}
-	}
-	sort.Strings(out)
-	return out
 }
 
 // parseSettingValue coerces the raw string the user passed via --value into
@@ -159,9 +145,9 @@ func NewSettingEditCmd() *cobra.Command {
 				return err
 			}
 			if result == 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), "Successfully updated!")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Successfully updated!")
 			} else {
-				fmt.Fprintln(cmd.OutOrStdout(), "Updating settings failed!")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Updating settings failed!")
 			}
 			return nil
 		},
@@ -224,14 +210,14 @@ func NewSettingExportCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				fmt.Fprintln(cmd.OutOrStdout(), string(out))
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
 			case "yaml":
 				out, err := yaml.Marshal(settings)
 				if err != nil {
 					return err
 				}
-				fmt.Fprintln(cmd.OutOrStdout(), "---")
-				fmt.Fprintln(cmd.OutOrStdout(), string(out))
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "---")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
 			}
 			return nil
 		},

--- a/cmd/signature.go
+++ b/cmd/signature.go
@@ -17,7 +17,7 @@ func NewSignatureCmd() *cobra.Command {
 		Short: "Signature management",
 		Long:  `Reloads, reports or updates the signatures of the distinct operating system versions.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprintln(cmd.OutOrStdout(), "Please use one of the sub commands!")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Please use one of the sub commands!")
 			_ = cmd.Help()
 		},
 	}
@@ -49,14 +49,14 @@ func NewSignatureReportCmd() *cobra.Command {
 				var totalOsVersions int
 
 				// Print signatures
-				fmt.Fprintln(cmd.OutOrStdout(), "Currently loaded signatures")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Currently loaded signatures")
 				breedNameList := make([]string, 0, len(signatures.Breeds))
 				for key := range signatures.Breeds {
 					breedNameList = append(breedNameList, key)
 				}
 				sort.Strings(breedNameList)
 				for _, breedName := range breedNameList {
-					fmt.Fprintln(cmd.OutOrStdout(), breedName)
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), breedName)
 					totalOsVersions += len(signatures.Breeds[breedName])
 					if len(signatures.Breeds[breedName]) > 0 {
 						osVersionNameList := make([]string, 0, len(signatures.Breeds[breedName]))
@@ -65,16 +65,16 @@ func NewSignatureReportCmd() *cobra.Command {
 						}
 						sort.Strings(osVersionNameList)
 						for _, versionName := range osVersionNameList {
-							fmt.Fprintf(cmd.OutOrStdout(), "\t%s\n", versionName)
+							_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\t%s\n", versionName)
 						}
 					} else {
-						fmt.Fprintln(cmd.OutOrStdout(), "\t(none)")
+						_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\t(none)")
 					}
 
 				}
-				fmt.Fprintf(cmd.OutOrStdout(), "\n%d breeds with %d total OS versions loaded\n", len(signatures.Breeds), totalOsVersions)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\n%d breeds with %d total OS versions loaded\n", len(signatures.Breeds), totalOsVersions)
 			} else {
-				fmt.Fprintln(cmd.OutOrStdout(), "No  breeds found in the signature, a signature update is recommended")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No  breeds found in the signature, a signature update is recommended")
 			}
 			return nil
 		},
@@ -94,7 +94,7 @@ func NewSignatureUpdateCmd() *cobra.Command {
 			}
 
 			eventId, _ := Client.BackgroundSignatureUpdate()
-			fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
 			return nil
 		},
 	}
@@ -112,7 +112,7 @@ func NewSignatureReloadCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintln(cmd.OutOrStdout(), "This functionality cannot be used in the new CLI until https://github.com/cobbler/cobbler/issues/3791 is implemented!")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "This functionality cannot be used in the new CLI until https://github.com/cobbler/cobbler/issues/3791 is implemented!")
 			return nil
 		},
 	}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -22,7 +22,7 @@ run for longer then 100 minutes are considered stalled.`,
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), res.(string))
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), res.(string))
 
 			return nil
 		},

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -62,7 +62,7 @@ See https://cobbler.readthedocs.io/en/latest/cobbler.html#cobbler-sync for more 
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
 			return nil
 		},
 	}

--- a/cmd/system.go
+++ b/cmd/system.go
@@ -479,7 +479,7 @@ func NewSystemAddCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "System %s created\n", system.Name)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "System %s created\n", system.Name)
 			return nil
 		},
 	}
@@ -694,14 +694,13 @@ func NewSystemGetAutoinstallCmd() *cobra.Command {
 				return err
 			}
 			if !systemExists {
-				//goland:noinspection GoErrorStringFormat
-				return fmt.Errorf("System does not exist")
+				return fmt.Errorf("system does not exist")
 			}
 			autoinstallRendered, err := Client.GenerateAutoinstall(systemName, "system", "name", "", "")
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), autoinstallRendered)
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), autoinstallRendered)
 			return nil
 		},
 	}
@@ -942,7 +941,7 @@ func reportSystems(cmd *cobra.Command, systemNames []string) error {
 			return err
 		}
 		printStructured(cmd, system)
-		fmt.Fprintln(cmd.OutOrStdout(), "")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 	}
 	return nil
 }
@@ -1028,15 +1027,15 @@ func NewSystemExportCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					fmt.Fprintln(cmd.OutOrStdout(), string(jsonDocument))
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(jsonDocument))
 				}
 				if formatOption == "yaml" {
 					yamlDocument, err := yaml.Marshal(system)
 					if err != nil {
 						return err
 					}
-					fmt.Fprintln(cmd.OutOrStdout(), "---")
-					fmt.Fprintln(cmd.OutOrStdout(), string(yamlDocument))
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "---")
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(yamlDocument))
 				}
 			}
 			return nil

--- a/cmd/system_group.go
+++ b/cmd/system_group.go
@@ -57,7 +57,7 @@ func newSystemGroupAddCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "System group %s created\n", created.Name)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "System group %s created\n", created.Name)
 			return nil
 		},
 	}
@@ -233,7 +233,7 @@ func newSystemGroupReportCmd() *cobra.Command {
 					return err
 				}
 				printStructured(cmd, g)
-				fmt.Fprintln(cmd.OutOrStdout(), "")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 			}
 			return nil
 		},

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -154,7 +154,7 @@ func NewTemplateAddCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Template %s created\n", created.Name)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Template %s created\n", created.Name)
 			return nil
 		},
 	}
@@ -324,7 +324,7 @@ func NewTemplateReportCmd() *cobra.Command {
 					return err
 				}
 				printStructured(cmd, t)
-				fmt.Fprintln(cmd.OutOrStdout(), "")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "")
 			}
 			return nil
 		},
@@ -379,14 +379,14 @@ func NewTemplateExportCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					fmt.Fprintln(cmd.OutOrStdout(), string(out))
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
 				case "yaml":
 					out, err := yaml.Marshal(t)
 					if err != nil {
 						return err
 					}
-					fmt.Fprintln(cmd.OutOrStdout(), "---")
-					fmt.Fprintln(cmd.OutOrStdout(), string(out))
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "---")
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
 				}
 			}
 			return nil
@@ -421,7 +421,7 @@ func NewTemplateContentCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprint(cmd.OutOrStdout(), content)
+			_, _ = fmt.Fprint(cmd.OutOrStdout(), content)
 			return nil
 		},
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -38,43 +38,43 @@ func covertFloatToUtcTime(t float64) (time.Time, error) {
 func printDumpVars(cmd *cobra.Command, blendedData map[string]interface{}) {
 	for key, value := range blendedData {
 		if value == nil {
-			fmt.Fprintf(cmd.OutOrStdout(), "%s:\n", key)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s:\n", key)
 			continue
 		}
 		valueType := reflect.TypeOf(value).Kind()
 		switch valueType {
 		case reflect.Bool:
-			fmt.Fprintf(cmd.OutOrStdout(), "%s: %t\n", key, value.(bool))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: %t\n", key, value.(bool))
 		case reflect.Int64:
-			fmt.Fprintf(cmd.OutOrStdout(), "%s: %d\n", key, value.(int64))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: %d\n", key, value.(int64))
 		case reflect.Int32:
-			fmt.Fprintf(cmd.OutOrStdout(), "%s: %d\n", key, value.(int32))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: %d\n", key, value.(int32))
 		case reflect.Int16:
-			fmt.Fprintf(cmd.OutOrStdout(), "%s: %d\n", key, value.(int16))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: %d\n", key, value.(int16))
 		case reflect.Int8:
-			fmt.Fprintf(cmd.OutOrStdout(), "%s: %d\n", key, value.(int8))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: %d\n", key, value.(int8))
 		case reflect.Int:
-			fmt.Fprintf(cmd.OutOrStdout(), "%s: %d\n", key, value.(int))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: %d\n", key, value.(int))
 		case reflect.Float32:
-			fmt.Fprintf(cmd.OutOrStdout(), "%s: %f\n", key, value.(float32))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: %f\n", key, value.(float32))
 		case reflect.Float64:
-			fmt.Fprintf(cmd.OutOrStdout(), "%s: %f\n", key, value.(float64))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: %f\n", key, value.(float64))
 		case reflect.Slice, reflect.Array:
 			arr := reflect.ValueOf(value)
-			fmt.Fprintf(cmd.OutOrStdout(), "%s: [", key)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: [", key)
 			for i := 0; i < arr.Len(); i++ {
 				if i+1 != arr.Len() {
-					fmt.Fprintf(cmd.OutOrStdout(), "'%v', ", arr.Index(i).Interface())
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "'%v', ", arr.Index(i).Interface())
 				} else {
-					fmt.Fprintf(cmd.OutOrStdout(), "'%v'", arr.Index(i).Interface())
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "'%v'", arr.Index(i).Interface())
 				}
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "]\n")
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "]\n")
 		case reflect.Map:
 			res2B, _ := json.Marshal(value)
-			fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", key, string(res2B))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", key, string(res2B))
 		default:
-			fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", key, value)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", key, value)
 		}
 	}
 }

--- a/cmd/validateAutoinstalls.go
+++ b/cmd/validateAutoinstalls.go
@@ -25,7 +25,7 @@ func NewValidateAutoinstallsCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Event ID: %s\n", eventId)
 			return nil
 		},
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -26,11 +26,11 @@ func NewVersionCmd() *cobra.Command {
 				return err
 			}
 			clientVersion, cliVersion, _ := getClientVersion()
-			fmt.Fprintf(cmd.OutOrStdout(), "Cobbler %s\n", version.Version)
-			fmt.Fprintf(cmd.OutOrStdout(), "  source: %s, %s\n", version.Gitstamp, version.Gitdate)
-			fmt.Fprintf(cmd.OutOrStdout(), "  build time: %s\n", version.Builddate)
-			fmt.Fprintf(cmd.OutOrStdout(), "  cli: %s\n", cliVersion)
-			fmt.Fprintf(cmd.OutOrStdout(), "  client: %s\n", clientVersion)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Cobbler %s\n", version.Version)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  source: %s, %s\n", version.Gitstamp, version.Gitdate)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  build time: %s\n", version.Builddate)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  cli: %s\n", cliVersion)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  client: %s\n", clientVersion)
 			return nil
 		},
 	}


### PR DESCRIPTION
This PR fixes two failures:

- golangci-lint doesn't run with go1.26
- Dependabot fails with goreleaser due to a lack of access to secrets