### PR TITLE
Docs: Add documentation for cobbler status

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -29,6 +29,7 @@ Long Usage:
    cobbler report <commands/report>
    cobbler reposync <commands/reposync>
    cobbler signature <commands/signature>
+   cobbler status <commands/status>
    cobbler sync <commands/sync>
    cobbler system <commands/system>
    cobbler validate-autoinstalls <commands/validate-autoinstalls>

--- a/docs/commands/status.rst
+++ b/docs/commands/status.rst
@@ -1,0 +1,14 @@
+**************
+cobbler status
+**************
+
+View the installation status of Cobbler Profiles and Systems.
+
+Example:
+
+.. code-block: shell
+
+   $ cobbler status
+
+This command displays the current status of all Cobbler Profiles and Systems. All installations that
+run for longer then 100 minutes are considered stalled.


### PR DESCRIPTION
Adds rudimentary documentation for the `cobbler status` command.

Fixes: https://github.com/cobbler/cobbler/issues/3616